### PR TITLE
removed handwritten targets in Makefile in favor of Makefile implicit rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,21 @@ CFLAGS +=  -Wall -Wextra
 
 LDFLAGS += -lhdf5 
 AUTOTARGETS = dextract dexta undexta dexqv 
+TARGETS = $(AUTOTARGETS) undexqv 
 
-all: $(AUTOTARGETS) undexqv 
+all: $(TARGETS)
 
 $(AUTOTARGETS): % : %.c
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@ 
 
 undexqv: undexqv.c 
-	$(CC) $(CFLAGS) -fno-strict-aliasing -o undexqv undexqv.c
+	$(CC) $(CFLAGS) -fno-strict-aliasing -o $@ $<
 
 clean:
-	rm -f dextract dexta undexta dexqv undexqv dextract.tar.gz
+	rm -f $(TARGETS) dextract.tar.gz
 
 install:
-	cp dextract dexta undexta dexqv undexqv ~/bin
+	cp $(TARGETS) ~/bin
 
 package:
 	tar -zcf dextract.tar.gz README *.c Makefile


### PR DESCRIPTION
While looking into the gcc34 versus gcc48 issues at MPI CBG, I upgraded the Makefile. As you can see, there is an automated target (line 8) that builds targets complying to the simple rule "foo.c -> foo". Adding shared.c as a dependency was not required because it was included in any case inside the source code (make based timestamp checking is hence obsolete). 
