### PR TITLE
Fixes compilation issue.

### DIFF
--- a/dexqv.c
+++ b/dexqv.c
@@ -11,6 +11,7 @@
  ********************************************************************************************/
 
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>


### PR DESCRIPTION
make exits with  

```dexqv.c: In function ‘main’:
dexqv.c:77:29: error: ‘INT32_MAX’ undeclared (first use in this function)
         QVcoding_Scan(input,INT32_MAX,NULL);
```

Fixed with importing ```stdint.h```, the same as https://github.com/thegenemyers/DALIGNER/issues/14